### PR TITLE
fix: Don't `exec` when not extracting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
                 shift
               fi
               unzip -qqd "\$TEMP" "\$TEMP/self.zip" >/dev/null
-              exec "\$TEMP/lib/$interpreter" --argv0 "\$0" "\$TEMP/orig/${name}" "\$@"
+              "\$TEMP/lib/$interpreter" --argv0 "\$0" "\$TEMP/orig/${name}" "\$@"
             fi
             exit 0
             #START_OF_ZIP#


### PR DESCRIPTION
`exec` does not work with the exit bash trap, so the temporary directory does not get deleted when the `exec`d process finishes