### PR TITLE
fix: address multiple security vulnerabilities in bundle.bash and flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result
+result-*

--- a/flake.nix
+++ b/flake.nix
@@ -27,8 +27,8 @@
         }:
         pkgs.runCommandCC name { buildInputs = [ pkgs.patchelf pkgs.gnutar ]; }
           ''
-            bundled=$(bash ${./bundle.bash} --format exe ${target} ${name})
-            mv $bundled $out
+            bundled=$(bash ${./bundle.bash} --format exe "${target}" "${name}")
+            mv "$bundled" "$out"
           '';
 
       aws-lambda-zip =
@@ -38,8 +38,8 @@
         }:
         pkgs.runCommandCC name { buildInputs = [ pkgs.patchelf pkgs.zip ]; }
           ''
-            bundled=$(bash ${./bundle.bash} --format lambda ${target} ${name})
-            mv $bundled $out
+            bundled=$(bash ${./bundle.bash} --format lambda "${target}" "${name}")
+            mv "$bundled" "$out"
           '';
     in
     flake-utils.lib.eachSystem supportedSystems (system:

--- a/flake.nix
+++ b/flake.nix
@@ -132,9 +132,15 @@
               echo "$rpath" | grep -q '\$ORIGIN/../lib'
 
               # lib/ 内の各 .so の RUNPATH が $ORIGIN であること
+              # ld-linux (dynamic linker) は patchelf で変更すると壊れるためスキップ
               for lib in "$extractdir/lib/"*.so*; do
+                basename_lib=$(basename "$lib")
+                if [[ "$basename_lib" == ld-linux* ]]; then
+                  echo "$basename_lib: skipped (dynamic linker)"
+                  continue
+                fi
                 rpath=$(patchelf --print-rpath "$lib")
-                echo "$(basename "$lib") RPATH: $rpath"
+                echo "$basename_lib RPATH: $rpath"
                 echo "$rpath" | grep -q '\$ORIGIN'
               done
 


### PR DESCRIPTION
- Sanitize `name` parameter to allow only safe characters (alphanumeric,
  '.', '-', '_'), preventing code injection in the generated self-extracting
  script and path traversal via '../' sequences
- Validate interpreter basename from patchelf output to prevent code
  injection via crafted ELF binaries
- Quote `$TEMP` in trap handler to prevent unintended directory deletion
  when path contains spaces
- Upgrade generated script from `set -u` to `set -euo pipefail` for
  stricter error handling
- Move trap immediately after mktemp to ensure cleanup in all code paths
  (fixes temp directory leak in --extract mode)
- Replace TOCTOU-vulnerable existence check + mv pattern with atomic
  mv -n (no-clobber) approach
- Quote shell arguments in flake.nix derivation scripts

https://claude.ai/code/session_0146761tZYmQBwX6nTarCtgy