### PR TITLE
Add Nix setup skill for Claude Code environments

### DIFF
--- a/.claude/skills/nix-setup.md
+++ b/.claude/skills/nix-setup.md
@@ -1,0 +1,54 @@
+# Nix Setup
+
+Nixがインストールされていない環境で `nix flake check` などのNixコマンドを実行する前に、以下の手順でNixをセットアップする。
+
+## 前提条件の確認
+
+```bash
+which nix 2>/dev/null && echo "Nix is already installed" || echo "Nix is not installed"
+```
+
+Nixがすでにインストールされている場合はインストール手順をスキップしてよい。
+
+## インストール手順
+
+Determinate Systems の nix-installer を使用する。
+
+### 方法1: curl経由（推奨）
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
+  --no-confirm \
+  --init none \
+  --extra-conf "sandbox = false"
+```
+
+### 方法2: GitHubリリースからバイナリ直接ダウンロード（方法1が403等で失敗する場合）
+
+```bash
+curl -sL -o /tmp/nix-installer https://github.com/DeterminateSystems/nix-installer/releases/latest/download/nix-installer-x86_64-linux
+chmod +x /tmp/nix-installer
+/tmp/nix-installer install linux \
+  --no-confirm \
+  --init none \
+  --extra-conf "sandbox = false"
+```
+
+## インストール後のPATH設定
+
+```bash
+export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+```
+
+## 使用例: flake check の実行
+
+```bash
+nix flake check
+```
+
+## オプションの説明
+
+- `--no-confirm`: 対話的な確認をスキップする
+- `--init none`: systemdが存在しないコンテナ環境向けのオプション
+- `--extra-conf "sandbox = false"`: コンテナ内ではサンドボックスが動作しないため無効化する
+- インストール後、`/nix/var/nix/profiles/default/bin` にPATHを通す必要がある

--- a/.claude/skills/nix-setup/SKILL.md
+++ b/.claude/skills/nix-setup/SKILL.md
@@ -1,6 +1,12 @@
+---
+name: nix-setup
+description: Install Nix in environments where it is not available. Use when you need to run nix commands like `nix flake check`, `nix build`, `nix develop` but Nix is not installed.
+user-invocable: false
+---
+
 # Nix Setup
 
-Nixがインストールされていない環境で `nix flake check` などのNixコマンドを実行する前に、以下の手順でNixをセットアップする。
+Nixがインストールされていない環境でNixコマンドを実行する必要がある場合、以下の手順でセットアップする。
 
 ## 前提条件の確認
 
@@ -8,22 +14,11 @@ Nixがインストールされていない環境で `nix flake check` などのN
 which nix 2>/dev/null && echo "Nix is already installed" || echo "Nix is not installed"
 ```
 
-Nixがすでにインストールされている場合はインストール手順をスキップしてよい。
+Nixがすでにインストールされている場合はこの手順をスキップする。
 
 ## インストール手順
 
-Determinate Systems の nix-installer を使用する。
-
-### 方法1: curl経由（推奨）
-
-```bash
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
-  --no-confirm \
-  --init none \
-  --extra-conf "sandbox = false"
-```
-
-### 方法2: GitHubリリースからバイナリ直接ダウンロード（方法1が403等で失敗する場合）
+Determinate Systems の nix-installer バイナリを GitHub Releases から直接ダウンロードして実行する。
 
 ```bash
 curl -sL -o /tmp/nix-installer https://github.com/DeterminateSystems/nix-installer/releases/latest/download/nix-installer-x86_64-linux
@@ -40,15 +35,8 @@ chmod +x /tmp/nix-installer
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 ```
 
-## 使用例: flake check の実行
-
-```bash
-nix flake check
-```
-
 ## オプションの説明
 
 - `--no-confirm`: 対話的な確認をスキップする
 - `--init none`: systemdが存在しないコンテナ環境向けのオプション
 - `--extra-conf "sandbox = false"`: コンテナ内ではサンドボックスが動作しないため無効化する
-- インストール後、`/nix/var/nix/profiles/default/bin` にPATHを通す必要がある


### PR DESCRIPTION
Add .claude/skills/nix-setup.md with instructions to install Nix using
Determinate Systems' nix-installer. Includes options for --init none
(no systemd), sandbox disabled, and a fallback method for environments
where the install script URL is blocked.

https://claude.ai/code/session_01WCPryMHVdE2juQZWGoK5ai