### PR TITLE
fix: ld-linuxをRPATHチェックから除外してnix flake checkを修正

### DIFF
--- a/.claude/skills/nix-setup/SKILL.md
+++ b/.claude/skills/nix-setup/SKILL.md
@@ -29,10 +29,31 @@ chmod +x /tmp/nix-installer
   --extra-conf "sandbox = false"
 ```
 
-## インストール後のPATH設定
+## インストール後のセットアップ
+
+### nix-daemon の起動
+
+`--init none` オプションを使用しているため、systemd が nix-daemon を管理しない。
+手動でバックグラウンド起動する必要がある。
 
 ```bash
+/nix/var/nix/profiles/default/bin/nix-daemon &
+```
+
+### nix コマンドの実行
+
+**重要**: `export PATH=...` はBashツールの呼び出しをまたいで引き継がれない。
+そのため、以降の nix コマンドはすべてフルパスで実行するか、各コマンドの先頭で再エクスポートする。
+
+フルパスで実行する場合:
+```bash
+/nix/var/nix/profiles/default/bin/nix flake check
+```
+
+再エクスポートして実行する場合:
+```bash
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+nix flake check
 ```
 
 ## オプションの説明

--- a/flake.nix
+++ b/flake.nix
@@ -132,9 +132,12 @@
               echo "$rpath" | grep -q '\$ORIGIN/../lib'
 
               # lib/ 内の各 .so の RUNPATH が $ORIGIN であること
+              # ただし ld-linux（インタープリタ）は除く
               for lib in "$extractdir/lib/"*.so*; do
+                libb=$(basename "$lib")
+                case "$libb" in ld-linux*) continue ;; esac
                 rpath=$(patchelf --print-rpath "$lib")
-                echo "$(basename "$lib") RPATH: $rpath"
+                echo "$libb RPATH: $rpath"
                 echo "$rpath" | grep -q '\$ORIGIN'
               done
 


### PR DESCRIPTION
ld-linux-x86-64.so.2はカーネルから直接呼び出されるインタープリタであり、
自身のRPATHを使用しないため、RPATHが設定されていなくても正常に動作する。
そのためsingle-exe-extract-rpathのチェックからld-linux*を除外する。

https://claude.ai/code/session_01RpfPJ2Ti43vxSfEyGegXfi